### PR TITLE
Remove BlockArrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /Manifest.toml
+docs/build/

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Invenia Technical Computing Corporation"]
 version = "0.1.0"
 
 [deps]
-BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,0 +1,112 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BlockDiagonals]]
+deps = ["FillArrays", "LinearAlgebra"]
+path = ".."
+uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
+version = "0.1.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[DocStringExtensions]]
+deps = ["LibGit2", "Markdown", "Pkg", "Test"]
+git-tree-sha1 = "0513f1a8991e9d83255e0140aace0d0fc4486600"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.0"
+
+[[Documenter]]
+deps = ["Base64", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "4a84478277020abfff208cde31ba1aa68a5bc572"
+uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+version = "0.23.0"
+
+[[FillArrays]]
+deps = ["LinearAlgebra", "Random", "SparseArrays", "Test"]
+git-tree-sha1 = "9ab8f76758cbabba8d7f103c51dce7f73fcf8e92"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "0.6.3"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "b34d7cef7b337321e97d22242c3c2b91f476748e"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.0"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Parsers]]
+deps = ["Dates", "Test"]
+git-tree-sha1 = "db2b35dedab3c0e46dc15996d170af07a5ab91c9"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "0.3.6"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,6 @@
 [deps]
+BlockDiagonals = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "~0.23"

--- a/src/BlockDiagonals.jl
+++ b/src/BlockDiagonals.jl
@@ -1,13 +1,10 @@
 module BlockDiagonals
 
-using BlockArrays
-using BlockArrays: AbstractBlockSizes, BlockSizes
 using FillArrays
 using LinearAlgebra
 
 export BlockDiagonal, blocks
-# reexport core interfaces from BlockArrays
-export Block, BlockSizes, blocksize, blocksizes, nblocks
+export blocksize, blocksizes, nblocks
 
 include("blockdiagonal.jl")
 include("base_maths.jl")

--- a/src/BlockDiagonals.jl
+++ b/src/BlockDiagonals.jl
@@ -1,6 +1,6 @@
 module BlockDiagonals
 
-using FillArrays
+using FillArrays: Zeros
 using LinearAlgebra
 
 export BlockDiagonal, blocks

--- a/src/base_maths.jl
+++ b/src/base_maths.jl
@@ -51,7 +51,7 @@ function Base.:+(B::BlockDiagonal, M::Diagonal)::BlockDiagonal
         nrows = size(block, 1)
         rows = row:(row + nrows-1)
         for (i, r) in enumerate(rows)
-            A[Block(p)][i, i] += d[r]
+            getblock(A, p)[i, i] += d[r]
         end
         row += nrows
     end
@@ -115,7 +115,7 @@ function Base.:*(B::BlockDiagonal, M::Diagonal)::BlockDiagonal
         ncols = size(block, 2)
         cols = col:(col + ncols-1)
         for (j, c) in enumerate(cols)
-            A[Block(p)][:, j] *= d[c]
+            getblock(A, p)[:, j] *= d[c]
         end
         col += ncols
     end
@@ -131,7 +131,7 @@ function Base.:*(M::Diagonal, B::BlockDiagonal)::BlockDiagonal
         nrows = size(block, 1)
         rows = row:(row + nrows-1)
         for (i, r) in enumerate(rows)
-            A[Block(p)][i, :] *= d[r]
+            getblock(A, p)[i, :] *= d[r]
         end
         row += nrows
     end

--- a/src/blockdiagonal.jl
+++ b/src/blockdiagonal.jl
@@ -1,10 +1,9 @@
 # Core functionality for the `BlockDiagonal` type
-# including implementing the BlockArray interface and AbstractArray interface
 
 """
-    BlockDiagonal{T, V<:AbstractMatrix{T}}
+    BlockDiagonal{T, V<:AbstractMatrix{T}} <: AbstractMatrix{T}
 
-A BlockMatrix with square blocks of type `V` on the diagonal, and zeros off the diagonal.
+A square matrix with square matrices on the diagonal, and zeros off the diagonal.
 """
 struct BlockDiagonal{T, V<:AbstractMatrix{T}} <: AbstractMatrix{T}
     blocks::Vector{V}
@@ -31,13 +30,54 @@ Return the on-diagonal blocks of B.
 blocks(B::BlockDiagonal) = B.blocks
 
 # BlockArrays-like functions
+"""
+    blocksizes(B::BlockDiagonal) -> Vector{Tuple}
+
+Return the size of each on-diagonal block in order.
+
+# Example
+```jldoctest
+julia> B = BlockDiagonal(rand(2, 2), rand(3, 3));
+
+julia> blocksizes(A)
+2-element Array{Tuple{Int64,Int64},1}:
+ (2, 2)
+ (3, 3)
+```
+"""
 blocksizes(B::BlockDiagonal) = map(size, blocks(B))
+
+"""
+    blocksize(B::BlockDiagonal, p::Integer, q::Integer=p) -> Tuple
+
+Return the size of the block at position `p, q`. Optionally specify only `p` to return the
+size of the p^th on-diagonal block.
+
+# Example
+```jldoctest
+julia> X = rand(2, 2); Y = rand(3, 3);
+
+julia> B = BlockDiagonal([X, Y]);
+
+julia> blocksize(B, 1)
+(2, 2)
+
+julia> blocksize(B, 1, 2)
+(2, 3)
+```
+"""
 blocksize(B::BlockDiagonal, p::Integer) = size(blocks(B)[p])
 function blocksize(B::BlockDiagonal, p::Integer, q::Integer)
     return size(blocks(B)[p], 1), size(blocks(B)[q], 2)
 end
 
-nblocks(B::BlockDiagonal, dim::Int) = dim > 2 ? 1 : length(blocks(B))
+"""
+    nblocks(B::BlockDiagonal[, dim])
+
+Return a tuple containing the number of blocks in each dimension. Optionally you can specify
+a dimension to just get the number of blocks in a single dimension i.e. on the diagonal.
+"""
+nblocks(B::BlockDiagonal, dim::Integer) = dim > 2 ? 1 : length(blocks(B))
 nblocks(B::BlockDiagonal) = length(blocks(B)), length(blocks(B))
 
 getblock(B::BlockDiagonal, p::Integer) = blocks(B)[p]

--- a/src/blockdiagonal.jl
+++ b/src/blockdiagonal.jl
@@ -2,28 +2,21 @@
 # including implementing the BlockArray interface and AbstractArray interface
 
 """
-    BlockDiagonal{T, V<:AbstractMatrix{T}, S<:AbstractBlockSizes} <: AbstractBlockMatrix{T}
+    BlockDiagonal{T, V<:AbstractMatrix{T}}
 
 A BlockMatrix with square blocks of type `V` on the diagonal, and zeros off the diagonal.
 """
-struct BlockDiagonal{T, V<:AbstractMatrix{T}, S<:AbstractBlockSizes} <: AbstractBlockMatrix{T}
+struct BlockDiagonal{T, V<:AbstractMatrix{T}} <: AbstractMatrix{T}
     blocks::Vector{V}
-    blocksizes::S
 
-    function BlockDiagonal{T, V, S}(blocks::Vector{V}, sizes::S) where {T, V<:AbstractMatrix{T}, S<:AbstractBlockSizes}
+    function BlockDiagonal{T, V}(blocks::Vector{V}) where {T, V<:AbstractMatrix{T}}
         all(is_square, blocks) || throw(ArgumentError("All blocks must be square."))
-        return new{T, V, S}(blocks, sizes)
+        return new{T, V}(blocks)
     end
 end
 
-function BlockDiagonal(blocks::Vector{V}, sizes::S) where {T, V<:AbstractMatrix{T}, S<:AbstractBlockSizes}
-    return BlockDiagonal{T, V, S}(blocks, sizes)
-end
-
-function BlockDiagonal(blocks::AbstractVector{<:AbstractMatrix})
-    # mapreduce would give Tuples; need Arrays
-    sizes = BlockSizes(([size(b, 1), size(b, 2)] for b in blocks)...)
-    return BlockDiagonal(blocks, sizes)
+function BlockDiagonal(blocks::Vector{V}) where {T, V<:AbstractMatrix{T}}
+    return BlockDiagonal{T, V}(blocks)
 end
 
 BlockDiagonal(B::BlockDiagonal) = B
@@ -37,33 +30,22 @@ Return the on-diagonal blocks of B.
 """
 blocks(B::BlockDiagonal) = B.blocks
 
-## AbstractBlockMatrix interface
-BlockArrays.blocksizes(B::BlockDiagonal) = B.blocksizes
-
-# Needs to be `Int` not `Integer` to avoid methods ambiguity. Can be changed after
-# BlockArrays v0.9 is released; see https://github.com/JuliaArrays/BlockArrays.jl/issues/82
-BlockArrays.blocksize(B::BlockDiagonal, p::Int) = size(blocks(B)[p])
-function BlockArrays.blocksize(B::BlockDiagonal, p::Int, q::Int)
+# BlockArrays-like functions
+blocksizes(B::BlockDiagonal) = map(size, blocks(B))
+blocksize(B::BlockDiagonal, p::Integer) = size(blocks(B)[p])
+function blocksize(B::BlockDiagonal, p::Integer, q::Integer)
     return size(blocks(B)[p], 1), size(blocks(B)[q], 2)
 end
 
-# Needs to be `Int` not `Integer` to avoid methods ambiguity. Can be changed after
-# BlockArrays v0.9 is released; see https://github.com/JuliaArrays/BlockArrays.jl/issues/82
-BlockArrays.nblocks(B::BlockDiagonal, dim::Int) = dim > 2 ? 1 : length(blocks(B))
-BlockArrays.nblocks(B::BlockDiagonal) = length(blocks(B)), length(blocks(B))
+nblocks(B::BlockDiagonal, dim::Int) = dim > 2 ? 1 : length(blocks(B))
+nblocks(B::BlockDiagonal) = length(blocks(B)), length(blocks(B))
 
-# Needs to be `Int` not `Integer` to avoid methods ambiguity. Can be changed after
-# BlockArrays v0.9 is released; see https://github.com/JuliaArrays/BlockArrays.jl/issues/82
-function BlockArrays.getblock(B::BlockDiagonal{T}, p::Int, q::Int) where T
+getblock(B::BlockDiagonal, p::Integer) = blocks(B)[p]
+function getblock(B::BlockDiagonal{T}, p::Integer, q::Integer) where T
     return p == q ? blocks(B)[p] : Zeros{T}(blocksize(B, p, q))
 end
 
-# Allow `B[Block(i)]` as shorthand for i^th diagonal block, i.e. `B[Block(i, i)]`
-BlockArrays.getblock(B::BlockDiagonal, p::Integer) = blocks(B)[p]
-Base.getindex(B::BlockDiagonal, block::Block{1}) = getblock(B, block.n[1])
-Base.setindex!(B::BlockDiagonal, v, block::Block{1}) = setblock!(B, v, block.n[1])
-
-function BlockArrays.setblock!(B::BlockDiagonal{T, V}, v::V, p::Integer) where {T, V}
+function setblock!(B::BlockDiagonal{T, V}, v::V, p::Integer) where {T, V}
     if blocksize(B, p) != size(v)
         throw(DimensionMismatch(
             "Cannot set block of size $(blocksize(B, p)) to block of size $(size(v))."
@@ -72,9 +54,7 @@ function BlockArrays.setblock!(B::BlockDiagonal{T, V}, v::V, p::Integer) where {
     return blocks(B)[p] = v
 end
 
-# Needs to be `Int` not `Integer` to avoid methods ambiguity. Can be changed after
-# BlockArrays v0.9 is released; see https://github.com/JuliaArrays/BlockArrays.jl/issues/82
-function BlockArrays.setblock!(B::BlockDiagonal{T, V}, v::V, p::Int, q::Int) where {T, V}
+function setblock!(B::BlockDiagonal{T, V}, v::V, p::Int, q::Int) where {T, V}
     p == q || throw(ArgumentError("Cannot set off-diagonal block ($p, $q) to non-zero value."))
     return setblock!(B, v, p)
 end
@@ -88,7 +68,7 @@ Base.parent(B::BlockDiagonal) = B.blocks
 function Base.setindex!(B::BlockDiagonal{T}, v, i::Integer, j::Integer) where T
     p, i_, j_ = _block_indices(B, i, j)
     if p > 0
-        @inbounds B[Block(p)][i_, end+j_] = v
+        @inbounds getblock(B, p)[i_, end+j_] = v
     elseif !iszero(v)
         throw(ArgumentError(
             "Cannot set entry ($i, $j) in off-diagonal-block to nonzero value $v."
@@ -100,11 +80,11 @@ end
 function Base.getindex(B::BlockDiagonal{T}, i::Integer, j::Integer) where T
     p, i, j = _block_indices(B, i, j)
     # if not in on-diagonal block `p` then value at `i, j` must be zero
-    return p > 0 ? B[Block(p)][i, end + j] : zero(T)
+    return p > 0 ? getblock(B, p)[i, end + j] : zero(T)
 end
 
-# Transform indices `i, j` (identifying entry `Matrix(B)[i, j]`) into indices `p, i, j`
-# such that the same entry is available via `B[Block(p)][i, end+j]`; `p = -1` if no such `p`.
+# Transform indices `i, j` (identifying entry `Matrix(B)[i, j]`) into indices `p, i, j` such
+# that the same entry is available via `getblock(B, p)[i, end+j]`; `p = -1` if no such `p`.
 function _block_indices(B::BlockDiagonal, i::Integer, j::Integer)
     all((0, 0) .< (i, j) .<= size(B)) || throw(BoundsError(B, (i, j)))
     nrows = size.(blocks(B), 1)

--- a/src/blockdiagonal.jl
+++ b/src/blockdiagonal.jl
@@ -44,14 +44,15 @@ julia> blocksizes(A)
  (2, 2)
  (3, 3)
 ```
+See also [`blocksize`](@ref) for accessing the size of a single block efficiently.
 """
 blocksizes(B::BlockDiagonal) = map(size, blocks(B))
 
 """
     blocksize(B::BlockDiagonal, p::Integer, q::Integer=p) -> Tuple
 
-Return the size of the block at position `p, q`. Optionally specify only `p` to return the
-size of the p^th on-diagonal block.
+Return the size of the p^th on-diagonal block. Optionally specify `q` to return the
+size of block `p, q`.
 
 # Example
 ```jldoctest
@@ -65,6 +66,7 @@ julia> blocksize(B, 1)
 julia> blocksize(B, 1, 2)
 (2, 3)
 ```
+See also [`blocksizes`](@ref) for accessing the size of all on-diagonal blocks easily.
 """
 blocksize(B::BlockDiagonal, p::Integer) = size(blocks(B)[p])
 function blocksize(B::BlockDiagonal, p::Integer, q::Integer)
@@ -74,11 +76,11 @@ end
 """
     nblocks(B::BlockDiagonal[, dim])
 
-Return a tuple containing the number of blocks in each dimension. Optionally you can specify
-a dimension to just get the number of blocks in a single dimension i.e. on the diagonal.
+Return the number of on-diagonal blocks.
+
+The total number of blocks in the matrix is `nblocks(B)^2`.
 """
-nblocks(B::BlockDiagonal, dim::Integer) = dim > 2 ? 1 : length(blocks(B))
-nblocks(B::BlockDiagonal) = length(blocks(B)), length(blocks(B))
+nblocks(B::BlockDiagonal) = length(blocks(B))
 
 getblock(B::BlockDiagonal, p::Integer) = blocks(B)[p]
 function getblock(B::BlockDiagonal{T}, p::Integer, q::Integer) where T

--- a/test/blockdiagonal.jl
+++ b/test/blockdiagonal.jl
@@ -67,6 +67,13 @@ using Test
         @test isequal_blocksizes(b1, b2) == false
     end
 
+    @testset "blocks size" begin
+        B = BlockDiagonal([rand(3, 3), rand(4, 4)])
+        @test nblocks(B) == 2
+        @test blocksizes(B) == [(3, 3), (4, 4)]
+        @test blocksize(B, 2) == blocksizes(B)[2]
+    end
+
     @testset "Equality" begin
         # Equality
         @test b1 == b1


### PR DESCRIPTION
- After helpful discussion in https://github.com/invenia/BlockDiagonals.jl/issues/8, it seems integration with BlockArrays is better done by contributing similar functionality straight into BlockArrays.jl (I might get to this in the future, but would also be happy for someone else to add it there)
- I still think a non-BlockArrays version of the package may be helpful (that just defines a simple wrapper type with efficient maths, in the spirit of e.g. https://github.com/MichielStock/Kronecker.jl)