### PR TITLE
Match the behaviour of `Diagonal` better

### DIFF
--- a/src/blockdiagonal.jl
+++ b/src/blockdiagonal.jl
@@ -26,7 +26,7 @@ function BlockDiagonal(blocks::AbstractVector{<:AbstractMatrix})
     return BlockDiagonal(blocks, sizes)
 end
 
-BlockDiagonal(B::BlockDiagonal) = copy(B)
+BlockDiagonal(B::BlockDiagonal) = B
 
 is_square(A::AbstractMatrix) = size(A, 1) == size(A, 2)
 

--- a/src/blockdiagonal.jl
+++ b/src/blockdiagonal.jl
@@ -83,6 +83,7 @@ end
 Base.Matrix(B::BlockDiagonal) = cat(blocks(B)...; dims=(1, 2))
 Base.size(B::BlockDiagonal) = sum(first∘size, blocks(B)), sum(last∘size, blocks(B))
 Base.similar(B::BlockDiagonal) = BlockDiagonal(map(similar, blocks(B)))
+Base.parent(B::BlockDiagonal) = B.blocks
 
 function Base.setindex!(B::BlockDiagonal{T}, v, i::Integer, j::Integer) where T
     p, i_, j_ = _block_indices(B, i, j)

--- a/test/blockdiagonal.jl
+++ b/test/blockdiagonal.jl
@@ -17,6 +17,8 @@ using Test
     b = rand(rng, N + N1)
 
     @testset "AbstractArray" begin
+        X = rand(2, 2); Y = rand(3, 3)
+
         @test size(b1) == (N, N)
         @test size(b1, 1) == N && size(b1, 2) == N
 
@@ -27,6 +29,11 @@ using Test
             end
         end
         @test all(eqs)
+
+        @testset "parent" begin
+            @test parent(b1) isa Vector{<:AbstractMatrix}
+            @test parent(BlockDiagonal([X, Y])) == [X, Y]
+        end
 
         @testset "similar" begin
             @test similar(b1) isa BlockDiagonal

--- a/test/blockdiagonal.jl
+++ b/test/blockdiagonal.jl
@@ -30,6 +30,15 @@ using Test
         end
         @test all(eqs)
 
+        @testset "BlockDiagonal does not copy" begin
+            Bxy = BlockDiagonal([X, Y])
+            X[1] = 1.1
+            @test Bxy[1] == 1.1
+            Bxy2 = BlockDiagonal(Bxy)
+            Bxy[2] = 2.2
+            @test X[2] == Bxy[2] == Bxy2[2] == 2.2
+        end
+
         @testset "parent" begin
             @test parent(b1) isa Vector{<:AbstractMatrix}
             @test parent(BlockDiagonal([X, Y])) == [X, Y]


### PR DESCRIPTION
- `parent` for `Diagonal` returns a `Vector`, so we also return a `Vector`
- `Diagonal(::Diagonal)` does not copy, so we also do not copy