### PR TITLE
add multiplication with vectors method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-FillArrays = "0.6, 0.7"
+FillArrays = "0.6, 0.7, 0.8"
 julia = "1"
 
 [extras]

--- a/src/base_maths.jl
+++ b/src/base_maths.jl
@@ -84,8 +84,9 @@ function _check_matmul_dims(A::AbstractMatrix, B::AbstractVecOrMat)
 end
 
 _mulblocksizes(bblocks, ::AbstractVector) = size.(bblocks, 1)
-_mulblocksizes(bblocks, M::AbstractMatrix) =
-    zip(size.(bblocks, 1), Base.Iterators.repeated(size(M, 2), length(bblocks)))
+function _mulblocksizes(bblocks, M::AbstractMatrix)
+    return zip(size.(bblocks, 1), Base.Iterators.repeated(size(M, 2), length(bblocks)))
+end
 
 Base.:*(B::BlockDiagonal, x::AbstractVector) = _mul(B, x)
 Base.:*(B::BlockDiagonal, X::AbstractMatrix) = _mul(B, X)


### PR DESCRIPTION
This seems to fix an oversight. Previously, there was no specialized `*(::BlockDiagonal,::AbstractVector)` method, such that this combination was handled by some generic `LinearAlgebra` method. Not surprisingly, this yields a giant performance gain.

I have kept the changes simple and minimal. There is quite some code duplication with the corresponding `*(::BlockDiagonal,::AbstractMatrix)` method, which can be reduced by means of a helper function and using `selectdim(y, 1, st:ed)` if desired.