### PR TITLE
Parametrize vector in BlockDiagonal

### DIFF
--- a/src/blockdiagonal.jl
+++ b/src/blockdiagonal.jl
@@ -1,7 +1,7 @@
 # Core functionality for the `BlockDiagonal` type
 
 """
-    BlockDiagonal{T, V<:AbstractMatrix{T}} <: AbstractMatrix{T}
+    BlockDiagonal{T, V<:AbstractMatrix{T}, AV<:AbstractVector{V}} <: AbstractMatrix{T}
 
 A matrix with matrices on the diagonal, and zeros off the diagonal.
 """
@@ -22,7 +22,7 @@ BlockDiagonal(B::BlockDiagonal) = B
 is_square(A::AbstractMatrix) = size(A, 1) == size(A, 2)
 
 """
-    blocks(B::BlockDiagonal{T, V}) -> Vector{V}
+    blocks(B::BlockDiagonal{T, V, AV}) -> AV
 
 Return the on-diagonal blocks of B.
 """

--- a/src/blockdiagonal.jl
+++ b/src/blockdiagonal.jl
@@ -5,16 +5,16 @@
 
 A matrix with matrices on the diagonal, and zeros off the diagonal.
 """
-struct BlockDiagonal{T, V<:AbstractMatrix{T}} <: AbstractMatrix{T}
-    blocks::Vector{V}
+struct BlockDiagonal{T, V<:AbstractMatrix{T}, AV<:AbstractVector{V}} <: AbstractMatrix{T}
+    blocks::AV
 
-    function BlockDiagonal{T, V}(blocks::Vector{V}) where {T, V<:AbstractMatrix{T}}
-        return new{T, V}(blocks)
+    function BlockDiagonal{T, V, AV}(blocks::AV) where {T, V<:AbstractMatrix{T}, AV<:AbstractVector{V}}
+        return new{T, V, AV}(blocks)
     end
 end
 
-function BlockDiagonal(blocks::Vector{V}) where {T, V<:AbstractMatrix{T}}
-    return BlockDiagonal{T, V}(blocks)
+function BlockDiagonal(blocks::AV) where {T, V<:AbstractMatrix{T}, AV<:AbstractVector{V}}
+    return BlockDiagonal{T, V, AV}(blocks)
 end
 
 BlockDiagonal(B::BlockDiagonal) = B


### PR DESCRIPTION
Right now the block matrices are hard-coded into a `Vector`, this makes it too restrictive for some actions like passing a `BlockDiagonal` to the GPU.
Parametrizing it as 
```julia
struct BlockDiagonal{T, V<:AbstractMatrix{T}, AV<:AbstractVector{V}} <: AbstractMatrix{T}
    blocks::AV

    function BlockDiagonal{T, V, AV}(blocks::AV) where {T, V<:AbstractMatrix{T}, AV<:AbstractVector{V}}
        return new{T, V, AV}(blocks)
    end
end
```
solve this issue.