### PR TITLE
drop isapprox defintion from tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "0.1.8"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
+ChainRulesTestUtils = "0.5.8"
 ChainRulesCore = "0.9"
 FillArrays = "0.6, 0.7, 0.8, 0.9, 0.10"
 julia = "1"

--- a/test/blockdiagonal.jl
+++ b/test/blockdiagonal.jl
@@ -9,10 +9,6 @@ function FiniteDifferences.to_vec(X::BlockDiagonal)
     return x, BlockDiagonal_from_vec
 end
 
-function Base.isapprox(C::Composite{<:BlockDiagonal}, D::BlockDiagonal; kwargs...)
-    return isapprox(C.blocks, D.blocks; kwargs...)
-end
-
 @testset "blockdiagonal.jl" begin
     rng = MersenneTwister(123456)
     N1, N2, N3 = 3, 4, 5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ using Test
 
 @testset "BlockDiagonals" begin
     # The doctests fail on x86, so only run them on 64-bit hardware
-    # Sys.WORD_SIZE == 64 && doctest(BlockDiagonals)
+    Sys.WORD_SIZE == 64 && doctest(BlockDiagonals)
     include("blockdiagonal.jl")
     include("base_maths.jl")
     include("linalg.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ using Test
 
 @testset "BlockDiagonals" begin
     # The doctests fail on x86, so only run them on 64-bit hardware
-    Sys.WORD_SIZE == 64 && doctest(BlockDiagonals)
+    # Sys.WORD_SIZE == 64 && doctest(BlockDiagonals)
     include("blockdiagonal.jl")
     include("base_maths.jl")
     include("linalg.jl")


### PR DESCRIPTION
This is the fix to #49 that is the "right way",
it requires https://github.com/JuliaDiff/ChainRulesTestUtils.jl/pull/84
to be merged first.

I made this in part to check that that PR worked.