### PR TITLE
Adjoint left-multiply

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.10"
+version = "0.1.11"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -9,8 +9,8 @@ FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-ChainRulesTestUtils = "0.5.8"
 ChainRulesCore = "0.9"
+ChainRulesTestUtils = "0.5.8"
 FillArrays = "0.6, 0.7, 0.8, 0.9, 0.10"
 julia = "1"
 

--- a/src/base_maths.jl
+++ b/src/base_maths.jl
@@ -152,5 +152,13 @@ function Base.:*(M::Diagonal, B::BlockDiagonal)::BlockDiagonal
     return A
 end
 
+function Base.:*(vt::Adjoint{T,<: AbstractVector}, B::BlockDiagonal{T}) where {T}
+    return (B' * parent(vt))'
+end
+
+function Base.:*(vt::Transpose{T,<: AbstractVector}, B::BlockDiagonal{T}) where {T}
+    return transpose(transpose(B) * parent(vt))
+end
+
 ## Division
 Base.:/(B::BlockDiagonal, n::Number) = BlockDiagonal(blocks(B) ./ n)

--- a/test/base_maths.jl
+++ b/test/base_maths.jl
@@ -87,6 +87,12 @@ using Test
             @test b1 * a ≈ Matrix(b1) * a
             @test_throws DimensionMismatch b1 * b
         end
+        @testset "Vector^T * BlockDiagonal" begin
+            @test a' * b1 isa {<:Number, <:Vector}
+            @test transpose(a) * b1 isa Transpose{<:Number, <:Vector}
+            @test a' * b1 ≈ a' * Matrix(b1)
+            @test transpose(a) * b1 ≈ transpose(a) * Matrix(b1)
+        end
 
         @testset "BlockDiagonal * Matrix" begin
             @test b1 * A isa Matrix

--- a/test/base_maths.jl
+++ b/test/base_maths.jl
@@ -88,7 +88,7 @@ using Test
             @test_throws DimensionMismatch b1 * b
         end
         @testset "Vector^T * BlockDiagonal" begin
-            @test a' * b1 isa {<:Number, <:Vector}
+            @test a' * b1 isa Adjoint{<:Number, <:Vector}
             @test transpose(a) * b1 isa Transpose{<:Number, <:Vector}
             @test a' * b1 ≈ a' * Matrix(b1)
             @test transpose(a) * b1 ≈ transpose(a) * Matrix(b1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using ChainRulesTestUtils
 using Documenter
 using FiniteDifferences # For overloading to_vec
 using Test
+using LinearAlgebra
 
 @testset "BlockDiagonals" begin
     # The doctests fail on x86, so only run them on 64-bit hardware


### PR DESCRIPTION
Fixes #16.
I was about to do this in a smarter way, but realized transposing and back will probably fall back to efficient methods. In that case, adjoint and transpose are implemented for BD, so this lets us write just enough to remove the ambiguity