### PR TITLE
Move chainrules stuff in its own file and modernise the tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 ChainRulesCore = "0.9"
-ChainRulesTestUtils = "0.5.8"
+ChainRulesTestUtils = "0.6"
 FillArrays = "0.6, 0.7, 0.8, 0.9, 0.10"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/BlockDiagonals.jl
+++ b/src/BlockDiagonals.jl
@@ -10,6 +10,7 @@ export blocksize, blocksizes, nblocks
 
 include("blockdiagonal.jl")
 include("base_maths.jl")
+include("chainrules.jl")
 include("linalg.jl")
 
 end  # end module

--- a/src/blockdiagonal.jl
+++ b/src/blockdiagonal.jl
@@ -17,11 +17,6 @@ function BlockDiagonal(blocks::Vector{V}) where {T, V<:AbstractMatrix{T}}
     return BlockDiagonal{T, V}(blocks)
 end
 
-function ChainRulesCore.rrule(::Type{<:BlockDiagonal}, blocks::Vector{V}) where {V}
-    BlockDiagonal_pullback(Δ::Composite) = (NO_FIELDS, Δ.blocks)
-    return BlockDiagonal(blocks), BlockDiagonal_pullback
-end
-
 BlockDiagonal(B::BlockDiagonal) = B
 
 is_square(A::AbstractMatrix) = size(A, 1) == size(A, 2)
@@ -120,23 +115,6 @@ function Base.Matrix(B::BlockDiagonal{T}) where {T}
         A[block_rows, block_cols] .= blocks(B)[n]
     end
     return A
-end
-
-function ChainRulesCore.rrule(::Type{<:Base.Matrix}, B::T) where {T<:BlockDiagonal}
-    nrows = size.(B.blocks, 1)
-    ncols = size.(B.blocks, 2)
-    function Matrix_pullback(Δ::Matrix)
-        row_idxs = cumsum(nrows) .- nrows .+ 1
-        col_idxs = cumsum(ncols) .- ncols .+ 1
-
-        Δblocks = map(eachindex(nrows)) do n
-            block_rows = row_idxs[n]:(row_idxs[n] + nrows[n] - 1)
-            block_cols = col_idxs[n]:(col_idxs[n] + ncols[n] - 1)
-            return Δ[block_rows, block_cols] 
-        end
-        return (NO_FIELDS, Composite{T}(blocks=Δblocks))
-    end
-    return Matrix(B), Matrix_pullback
 end
 
 Base.size(B::BlockDiagonal) = sum(first∘size, blocks(B)), sum(last∘size, blocks(B))

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -1,0 +1,24 @@
+# constructor
+function ChainRulesCore.rrule(::Type{<:BlockDiagonal}, blocks::Vector{V}) where {V}
+    BlockDiagonal_pullback(Δ::Composite) = (NO_FIELDS, Δ.blocks)
+    return BlockDiagonal(blocks), BlockDiagonal_pullback
+end
+
+# densification
+function ChainRulesCore.rrule(::Type{<:Base.Matrix}, B::T) where {T<:BlockDiagonal}
+    nrows = size.(B.blocks, 1)
+    ncols = size.(B.blocks, 2)
+    function Matrix_pullback(Δ::Matrix)
+        row_idxs = cumsum(nrows) .- nrows .+ 1
+        col_idxs = cumsum(ncols) .- ncols .+ 1
+
+        Δblocks = map(eachindex(nrows)) do n
+            block_rows = row_idxs[n]:(row_idxs[n] + nrows[n] - 1)
+            block_cols = col_idxs[n]:(col_idxs[n] + ncols[n] - 1)
+            return Δ[block_rows, block_cols]
+        end
+        return (NO_FIELDS, Composite{T}(blocks=Δblocks))
+    end
+    return Matrix(B), Matrix_pullback
+end
+

--- a/test/blockdiagonal.jl
+++ b/test/blockdiagonal.jl
@@ -69,21 +69,6 @@ end
         end
     end  # AbstractArray
 
-    @testset "ChainRules" begin
-        @testset "BlockDiagonal" begin
-            x = [randn(1, 2), randn(2, 2)]
-            x̄ = [randn(1, 2), randn(2, 2)]
-            ȳ = Composite{typeof(BlockDiagonal(x))}(blocks=[randn(1, 2), randn(2, 2)])
-            rrule_test(BlockDiagonal, ȳ, (x, x̄))
-        end
-        @testset "Matrix" begin
-            D = BlockDiagonal([randn(1, 2), randn(2, 2)])
-            D̄ = Composite{typeof(D)}((blocks=[randn(1, 2), randn(2, 2)]), )
-            Ȳ = randn(size(D))
-            rrule_test(Matrix, Ȳ, (D, D̄))
-        end
-    end
-
     @testset "isequal_blocksizes" begin
         @test isequal_blocksizes(b1, b1) == true
         @test isequal_blocksizes(b1, similar(b1)) == true

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,0 +1,15 @@
+@testset "chainrules.jl" begin
+    @testset "BlockDiagonal" begin
+        x = [randn(1, 2), randn(2, 2)]
+        x̄ = [randn(1, 2), randn(2, 2)]
+        ȳ = Composite{typeof(BlockDiagonal(x))}(blocks=[randn(1, 2), randn(2, 2)])
+        rrule_test(BlockDiagonal, ȳ, (x, x̄))
+    end
+
+    @testset "Matrix" begin
+        D = BlockDiagonal([randn(1, 2), randn(2, 2)])
+        D̄ = Composite{typeof(D)}((blocks=[randn(1, 2), randn(2, 2)]), )
+        Ȳ = randn(size(D))
+        rrule_test(Matrix, Ȳ, (D, D̄))
+    end
+end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,15 +1,11 @@
 @testset "chainrules.jl" begin
     @testset "BlockDiagonal" begin
         x = [randn(1, 2), randn(2, 2)]
-        x̄ = [randn(1, 2), randn(2, 2)]
-        ȳ = Composite{typeof(BlockDiagonal(x))}(blocks=[randn(1, 2), randn(2, 2)])
-        rrule_test(BlockDiagonal, ȳ, (x, x̄))
+        test_rrule(BlockDiagonal, x)
     end
 
     @testset "Matrix" begin
         D = BlockDiagonal([randn(1, 2), randn(2, 2)])
-        D̄ = Composite{typeof(D)}((blocks=[randn(1, 2), randn(2, 2)]), )
-        Ȳ = randn(size(D))
-        rrule_test(Matrix, Ȳ, (D, D̄))
+        test_rrule(Matrix, D)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,5 +11,6 @@ using LinearAlgebra
     Sys.WORD_SIZE == 64 && doctest(BlockDiagonals)
     include("blockdiagonal.jl")
     include("base_maths.jl")
+    include("chainrules.jl")
     include("linalg.jl")
 end  # tests


### PR DESCRIPTION
It is split in two commits, one moves the definitions and tests and the other one modernises them. Might be easier to view by commit.