### PR TITLE
rrule for BlockDiagonal * Vector multiplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /Manifest.toml
 docs/build/
+dev/*

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.11"
+version = "0.1.14"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 ChainRulesCore = "0.9"
-ChainRulesTestUtils = "0.6"
+ChainRulesTestUtils = "0.6.3"
 FillArrays = "0.6, 0.7, 0.8, 0.9, 0.10"
 julia = "1"
 

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -36,7 +36,10 @@ function ChainRulesCore.rrule(::typeof(*), bm::BlockDiagonal{T, V}, v::AbstractV
         Δblocks = map(eachindex(nrows)) do i
             block_rows = row_idxs[i]:(row_idxs[i] + nrows[i] - 1)
             block_cols = col_idxs[i]:(col_idxs[i] + ncols[i] - 1)
-            return Δ[block_rows] * v[block_cols]'
+            return InplaceableThunk(
+                @thunk(Δ[block_rows] * v[block_cols]'),
+                X̄ -> mul!(X̄, Δ[block_rows], v[block_cols]', true, true)
+            )
         end
         return (
             NO_FIELDS,

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -34,13 +34,10 @@ function ChainRulesCore.rrule(::typeof(*), bm::BlockDiagonal{T, V}, v::AbstractV
     low2s = [1, (1 .+ high2s)...]
 
     function bm_vector_mul_pullback(Δ)
+        blocks = [Δ[low1s[i]:high1s[i]] * v[low2s[i]:high2s[i]]' for i in 1:length(sizes)]
         return (
             NO_FIELDS,
-            BlockDiagonal(
-                [
-                    Δ[low1s[i]:high1s[i]] * v[low2s[i]:high2s[i]]' for i in 1:length(sizes)
-                ]
-            ),
+            Composite{BlockDiagonal{T, V}}(;blocks),
             bm' * Δ,
         )
     end

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -34,7 +34,7 @@ function ChainRulesCore.rrule(::typeof(*), bm::BlockDiagonal{T, V}, v::AbstractV
     low2s = [1, (1 .+ high2s)...]
 
     function bm_vector_mul_pullback(Δ)
-        blocks = [Δ[low1s[i]:high1s[i]] * v[low2s[i]:high2s[i]]' for i in 1:length(sizes)]
+        blocks = [Δ[low1s[i]:high1s[i]] * v[low2s[i]:high2s[i]]' for i in 1:length(bm.blocks)]
         return (
             NO_FIELDS,
             Composite{BlockDiagonal{T, V}}(;blocks),

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -23,7 +23,12 @@ function ChainRulesCore.rrule(::Type{<:Base.Matrix}, B::T) where {T<:BlockDiagon
 end
 
 # multiplication
-function ChainRulesCore.rrule(::typeof(*), bm::BlockDiagonal{T, V}, v::AbstractVector{T}) where {T<:Union{Real, Complex}, V<:AbstractArray{T, 2}}
+function ChainRulesCore.rrule(
+        ::typeof(*),
+        bm::BlockDiagonal{T, V},
+        v::StridedVector{T}
+    ) where {T<:Union{Real, Complex}, V<:Matrix{T}}
+
     y = bm * v
 
     # needed for computing Δ * v' blockwise

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -41,7 +41,10 @@ function ChainRulesCore.rrule(::typeof(*), bm::BlockDiagonal{T, V}, v::AbstractV
         return (
             NO_FIELDS,
             Composite{BlockDiagonal{T, V}}(;blocks=Δblocks),
-            bm' * Δ,
+            InplaceableThunk(
+                @thunk(bm' * Δ),
+                X̄ -> mul!(X̄, bm', Δ, true, true)
+            ),
         )
     end
     return y, bm_vector_mul_pullback

--- a/test/blockdiagonal.jl
+++ b/test/blockdiagonal.jl
@@ -3,12 +3,6 @@ using BlockDiagonals: isequal_blocksizes
 using Random
 using Test
 
-function FiniteDifferences.to_vec(X::BlockDiagonal)
-    x, blocks_from_vec = to_vec(X.blocks)
-    BlockDiagonal_from_vec(x_vec) = BlockDiagonal(blocks_from_vec(x_vec))
-    return x, BlockDiagonal_from_vec
-end
-
 @testset "blockdiagonal.jl" begin
     rng = MersenneTwister(123456)
     N1, N2, N3 = 3, 4, 5

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -8,4 +8,10 @@
         D = BlockDiagonal([randn(1, 2), randn(2, 2)])
         test_rrule(Matrix, D)
     end
+
+    @testset "BlockDiagonal * Vector" begin
+        D = BlockDiagonal([rand(2, 3), rand(3, 3)])
+        v = rand(6)
+        test_rrule(*, D, v)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,12 @@ using FiniteDifferences # For overloading to_vec
 using Test
 using LinearAlgebra
 
+function FiniteDifferences.to_vec(X::BlockDiagonal)
+    x, blocks_from_vec = to_vec(X.blocks)
+    BlockDiagonal_from_vec(x_vec) = BlockDiagonal(blocks_from_vec(x_vec))
+    return x, BlockDiagonal_from_vec
+end
+
 @testset "BlockDiagonals" begin
     # The doctests fail on x86, so only run them on 64-bit hardware
     Sys.WORD_SIZE == 64 && doctest(BlockDiagonals)


### PR DESCRIPTION
This is a draft, needs some love, thunking, and benchmarking.

- [x] love
- [x] thunking
- [x] benchmarking
- [x] bump patch

Putting it out for initial review.

One point in particular I want to emphasise is that the 
```
julia> b = BlockDiagonal([rand(2, 3), 2*ones(3, 3)])
5×6 BlockDiagonal{Float64,Array{Float64,2}}:
 0.127925  0.763018  0.590756  0.0  0.0  0.0
 0.21821   0.792263  0.696002  0.0  0.0  0.0
 0.0       0.0       0.0       2.0  2.0  2.0
 0.0       0.0       0.0       2.0  2.0  2.0
 0.0       0.0       0.0       2.0  2.0  2.0

julia> m = Matrix(b);

julia> v = rand(6);

julia> ȳ = rand(5);

julia> y, pb = rrule(*, m, v); unthunk(pb(ȳ)[2])
5×6 Array{Float64,2}:
 0.0412828  0.0166629  0.053694  0.0317837  0.0805506  0.0148633
 0.217186   0.0876624  0.28248   0.167212   0.42377    0.0781948
 0.452638   0.182698   0.588718  0.348487   0.883182   0.162966
 0.410036   0.165502   0.533308  0.315688   0.800058   0.147628
 0.435955   0.175964   0.567019  0.335643   0.85063    0.15696

julia> y, pb = rrule(*, b, v); unthunk(pb(ȳ)[2])
5×6 BlockDiagonal{Float64,Array{Float64,2}}:
 0.0412828  0.0166629  0.053694  0.0       0.0       0.0
 0.217186   0.0876624  0.28248   0.0       0.0       0.0
 0.0        0.0        0.0       0.348487  0.883182  0.162966
 0.0        0.0        0.0       0.315688  0.800058  0.147628
 0.0        0.0        0.0       0.335643  0.85063   0.15696
```

derivative with respect to `BlockDiagonal` is not the same as the one when using a `Matrix` (the off-block-diagonal elements are zero). This removes the redundant calculation of derivatives w.r.t. the off-block-diagonal elements.