### PR TITLE
move to_vec to src/

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,4 +22,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ChainRulesTestUtils", "Documenter", "FiniteDifferences", "Random", "Test"]
+test = ["ChainRulesTestUtils", "Documenter", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.15"
+version = "0.1.16"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,12 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.14"
+version = "0.1.15"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
@@ -17,7 +18,6 @@ julia = "1"
 [extras]
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/BlockDiagonals.jl
+++ b/src/BlockDiagonals.jl
@@ -3,6 +3,7 @@ module BlockDiagonals
 using Base: @propagate_inbounds
 using ChainRulesCore
 using FillArrays: Zeros
+using FiniteDifferences
 using LinearAlgebra
 
 export BlockDiagonal, blocks
@@ -12,5 +13,6 @@ include("blockdiagonal.jl")
 include("base_maths.jl")
 include("chainrules.jl")
 include("linalg.jl")
+include("finitedifferences.jl")
 
 end  # end module

--- a/src/finitedifferences.jl
+++ b/src/finitedifferences.jl
@@ -1,0 +1,6 @@
+function FiniteDifferences.to_vec(X::BlockDiagonal)
+    x, blocks_from_vec = to_vec(blocks(X))
+    BlockDiagonal_from_vec(x_vec) = BlockDiagonal(blocks_from_vec(x_vec))
+    return x, BlockDiagonal_from_vec
+end
+

--- a/test/finitedifferences.jl
+++ b/test/finitedifferences.jl
@@ -1,0 +1,14 @@
+function test_to_vec(x::T; check_inferred = true) where {T}
+    check_inferred && @inferred to_vec(x)
+    x_vec, back = to_vec(x)
+    @test x_vec isa Vector
+    @test all(s -> s isa Real, x_vec)
+    check_inferred && @inferred back(x_vec)
+    @test x == back(x_vec)
+    return nothing
+end
+
+@testset "finitedifferences.jl" begin
+    b = BlockDiagonal([rand(2, 2), rand(3, 4)])
+    test_to_vec(b)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,12 +6,6 @@ using FiniteDifferences # For overloading to_vec
 using Test
 using LinearAlgebra
 
-function FiniteDifferences.to_vec(X::BlockDiagonal)
-    x, blocks_from_vec = to_vec(X.blocks)
-    BlockDiagonal_from_vec(x_vec) = BlockDiagonal(blocks_from_vec(x_vec))
-    return x, BlockDiagonal_from_vec
-end
-
 @testset "BlockDiagonals" begin
     # The doctests fail on x86, so only run them on 64-bit hardware
     Sys.WORD_SIZE == 64 && doctest(BlockDiagonals)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ using LinearAlgebra
 
 @testset "BlockDiagonals" begin
     # The doctests fail on x86, so only run them on 64-bit hardware
-    #Sys.WORD_SIZE == 64 && doctest(BlockDiagonals)
+    Sys.WORD_SIZE == 64 && doctest(BlockDiagonals)
     include("blockdiagonal.jl")
     include("base_maths.jl")
     include("chainrules.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,9 +8,10 @@ using LinearAlgebra
 
 @testset "BlockDiagonals" begin
     # The doctests fail on x86, so only run them on 64-bit hardware
-    Sys.WORD_SIZE == 64 && doctest(BlockDiagonals)
+    #Sys.WORD_SIZE == 64 && doctest(BlockDiagonals)
     include("blockdiagonal.jl")
     include("base_maths.jl")
     include("chainrules.jl")
+    include("finitedifferences.jl")
     include("linalg.jl")
 end  # tests


### PR DESCRIPTION
In one of our internal packages we wanted to do some custom testing with BlockDiagonals and FiniteDifferences. Having to_vec defined in src allows to reuse that code.