### PR TITLE
Add pullback for AbstractArray type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.21"
+version = "0.1.22"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -4,7 +4,10 @@ function _BlockDiagonal_pullback(Δ::AbstractThunk, project)
     _BlockDiagonal_pullback(unthunk(Δ), project)
 end
 _BlockDiagonal_pullback(Δ::BlockDiagonal, project) = (NoTangent(), Δ.blocks)
-_BlockDiagonal_pullback(Δ::Matrix, project) = _BlockDiagonal_pullback(project(Δ), project)
+function _BlockDiagonal_pullback(Δ::Matrix, project)
+    _BlockDiagonal_pullback(project(Δ), project) # TODO AbstractArray
+end
+
 function ChainRulesCore.rrule(::Type{<:BlockDiagonal}, blocks::Vector{V}) where {V}
     y = BlockDiagonal(blocks)
     project = ProjectTo(y)

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -2,12 +2,12 @@
 _BlockDiagonal_pullback(Δ::Tangent) = (NoTangent(), Δ.blocks)
 _BlockDiagonal_pullback(Δ::AbstractThunk) = _BlockDiagonal_pullback(unthunk(Δ))
 _BlockDiagonal_pullback(Δ::BlockDiagonal) = (NoTangent(), Δ.blocks)
-_BlockDiagonal_pullback(Δ::Matrix, project) = (NoTangent(), project(Δ'))
+_BlockDiagonal_pullback(Δ::Matrix, project) = (NoTangent(), project(Δ))
 function ChainRulesCore.rrule(::Type{<:BlockDiagonal}, blocks::Vector{V}) where {V}
     y = BlockDiagonal(blocks)
     project = ProjectTo(y)
     BlockDiagonal_pullback(Δ) = _BlockDiagonal_pullback(Δ, project)
-    return y, BlockDiagonal_pullback
+    return y', BlockDiagonal_pullback
 end
 
 # densification

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -5,7 +5,7 @@ _BlockDiagonal_pullback(Δ::BlockDiagonal) = (NoTangent(), Δ.blocks)
 _BlockDiagonal_pullback(Δ::Matrix, project) = (NoTangent(), project(Δ))
 function ChainRulesCore.rrule(::Type{<:BlockDiagonal}, blocks::Vector{V}) where {V}
     y = BlockDiagonal(blocks)
-    project = ProjectTo(y)
+    project = ProjectTo(y')
     BlockDiagonal_pullback(Δ) = _BlockDiagonal_pullback(Δ, project)
     return y, BlockDiagonal_pullback
 end

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -2,8 +2,12 @@
 _BlockDiagonal_pullback(Δ::Tangent) = (NoTangent(), Δ.blocks)
 _BlockDiagonal_pullback(Δ::AbstractThunk) = _BlockDiagonal_pullback(unthunk(Δ))
 _BlockDiagonal_pullback(Δ::BlockDiagonal) = (NoTangent(), Δ.blocks)
+_BlockDiagonal_pullback(Δ::Matrix, project) = (NoTangent(), project(Δ))
 function ChainRulesCore.rrule(::Type{<:BlockDiagonal}, blocks::Vector{V}) where {V}
-    return BlockDiagonal(blocks), _BlockDiagonal_pullback
+    y = BlockDiagonal(blocks)
+    project = ProjectTo(y)
+    BlockDiagonal_pullback(Δ) = _BlockDiagonal_pullback(Δ, project)
+    return y, BlockDiagonal_pullback
 end
 
 # densification

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -2,10 +2,10 @@
 _BlockDiagonal_pullback(Δ::Tangent) = (NoTangent(), Δ.blocks)
 _BlockDiagonal_pullback(Δ::AbstractThunk) = _BlockDiagonal_pullback(unthunk(Δ))
 _BlockDiagonal_pullback(Δ::BlockDiagonal) = (NoTangent(), Δ.blocks)
-_BlockDiagonal_pullback(Δ::Matrix, project) = (NoTangent(), project(Δ))
+_BlockDiagonal_pullback(Δ::Matrix, project) = (NoTangent(), project(Δ'))
 function ChainRulesCore.rrule(::Type{<:BlockDiagonal}, blocks::Vector{V}) where {V}
     y = BlockDiagonal(blocks)
-    project = ProjectTo(y')
+    project = ProjectTo(y)
     BlockDiagonal_pullback(Δ) = _BlockDiagonal_pullback(Δ, project)
     return y, BlockDiagonal_pullback
 end

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -1,5 +1,8 @@
 # # constructor
-_BlockDiagonal_pullback(Δ::AbstractThunk, project) = _BlockDiagonal_pullback(unthunk(Δ))
+_BlockDiagonal_pullback(Δ::Tangent, project) = (NoTangent(), Δ.blocks)
+function _BlockDiagonal_pullback(Δ::AbstractThunk, project)
+    _BlockDiagonal_pullback(unthunk(Δ), project)
+end
 _BlockDiagonal_pullback(Δ::BlockDiagonal, project) = (NoTangent(), Δ.blocks)
 _BlockDiagonal_pullback(Δ::Matrix, project) = _BlockDiagonal_pullback(project(Δ), project)
 function ChainRulesCore.rrule(::Type{<:BlockDiagonal}, blocks::Vector{V}) where {V}

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -16,13 +16,12 @@ function _BlockDiagonal_pullback(Δ::AbstractArray, nrows, ncols)
 end
 
 function ChainRulesCore.rrule(::Type{<:BlockDiagonal}, blocks::Vector{V}) where {V}
-    y = BlockDiagonal(blocks)
     nrows = size.(blocks, 1)
     ncols = size.(blocks, 2)
     function BlockDiagonal_pullback(Δ)
         return _BlockDiagonal_pullback(Δ, nrows, ncols)
     end
-    return y, BlockDiagonal_pullback
+    return BlockDiagonal(blocks), BlockDiagonal_pullback
 end
 
 # densification

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -1,13 +1,12 @@
-# constructor
-_BlockDiagonal_pullback(Δ::Tangent) = (NoTangent(), Δ.blocks)
-_BlockDiagonal_pullback(Δ::AbstractThunk) = _BlockDiagonal_pullback(unthunk(Δ))
-_BlockDiagonal_pullback(Δ::BlockDiagonal) = (NoTangent(), Δ.blocks)
-_BlockDiagonal_pullback(Δ::Matrix, project) = (NoTangent(), project(Δ))
+# # constructor
+_BlockDiagonal_pullback(Δ::AbstractThunk, project) = _BlockDiagonal_pullback(unthunk(Δ))
+_BlockDiagonal_pullback(Δ::BlockDiagonal, project) = (NoTangent(), Δ.blocks)
+_BlockDiagonal_pullback(Δ::Matrix, project) = _BlockDiagonal_pullback(project(Δ), project)
 function ChainRulesCore.rrule(::Type{<:BlockDiagonal}, blocks::Vector{V}) where {V}
     y = BlockDiagonal(blocks)
     project = ProjectTo(y)
     BlockDiagonal_pullback(Δ) = _BlockDiagonal_pullback(Δ, project)
-    return y', BlockDiagonal_pullback
+    return y, BlockDiagonal_pullback
 end
 
 # densification

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,16 +1,21 @@
 @testset "chainrules.jl" begin
     @testset "BlockDiagonal" begin
         x = [randn(1, 2), randn(2, 2)]
-        test_rrule(BlockDiagonal, x; check_inferred=false)
+        test_rrule(BlockDiagonal, x)
+        test_rrule(BlockDiagonal, x; output_tangent=Tangent{BlockDiagonal}(;blocks=x))
+
+        b = BlockDiagonal(x)
+        m = Matrix(b)
+        y, pb = rrule(BlockDiagonal, x)
+        # want to test `output_tangent=m`, but can't do it directly because of
+        # https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/199
+        # so just compare the tangent to the tangent we get from the same BlockDiagonal
+        @test pb(b) == pb(m)
     end
 
     @testset "Matrix" begin
         D = BlockDiagonal([randn(1, 2), randn(2, 2)])
         test_rrule(Matrix, D)
-        D_dense = collect(D) + reverse(collect(D), dims=2)
-        @test BlockDiagonals._BlockDiagonal_pullback(D, ProjectTo(D)) ==
-            BlockDiagonals._BlockDiagonal_pullback(D_dense, ProjectTo(D))
-
     end
 
     @testset "BlockDiagonal * Vector" begin

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,13 +1,17 @@
 @testset "chainrules.jl" begin
     @testset "BlockDiagonal" begin
         x = [randn(1, 2), randn(2, 2)]
-        test_rrule(BlockDiagonal, x)
-        test_rrule(BlockDiagonal, x; output_tangent=Tangent{BlockDiagonal}(;blocks=x))
+        test_rrule(BlockDiagonal, x; check_inferred=false)
+        test_rrule(BlockDiagonal, x; output_tangent=Tangent{BlockDiagonal}(;blocks=x), check_inferred=false)
     end
 
     @testset "Matrix" begin
         D = BlockDiagonal([randn(1, 2), randn(2, 2)])
         test_rrule(Matrix, D)
+        D_dense = collect(D) + reverse(collect(D), dims=2)
+        @test BlockDiagonals._BlockDiagonal_pullback(D, ProjectTo(D)) ==
+            BlockDiagonals._BlockDiagonal_pullback(D_dense, ProjectTo(D))
+
     end
 
     @testset "BlockDiagonal * Vector" begin

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -2,7 +2,6 @@
     @testset "BlockDiagonal" begin
         x = [randn(1, 2), randn(2, 2)]
         test_rrule(BlockDiagonal, x; check_inferred=false)
-        test_rrule(BlockDiagonal, x; output_tangent=Tangent{BlockDiagonal}(;blocks=x), check_inferred=false)
     end
 
     @testset "Matrix" begin


### PR DESCRIPTION
We had to add `_BlockDiagonal_pullback(::Matrix)` to get AD working with [`LinearMixingModels.jl`](https://github.com/invenia/LinearMixingModels.jl). 

This is a WIP since I am unsure exactly how I should test it. I have added something, but might be missing some important checks or testing the wrong thing.

I also think there is still a small issue, as I had to introduce a `check_inferred=false` in to the tests. This should not be merged until this is fixed. The error message from this failure without the `kwarg` was:

```
 Got exception outside of a @test
  return type Tuple{BlockDiagonal{Float64, Matrix{Float64}}, BlockDiagonals.var"#BlockDiagonal_pullback#67"{ProjectTo{BlockDiagonal, NamedTuple{(:blocks, :blocksizes), Tuple{Vector{ProjectTo{AbstractArray, NamedTuple{(:element, :axes), Tuple{ProjectTo{Float64, NamedTuple{(), Tuple{}}}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}}}}, Vector{Tuple{Int64, Int64}}}}}}} does not match inferred return type Tuple{BlockDiagonal{Float64, Matrix{Float64}}, BlockDiagonals.var"#BlockDiagonal_pullback#67"{_A} where _A}
```