### PR TITLE
Pretty printing for sparse arrays

### DIFF
--- a/src/blockdiagonal.jl
+++ b/src/blockdiagonal.jl
@@ -168,3 +168,12 @@ function Base.copy!(dest::BlockDiagonal, src::BlockDiagonal)
     end
     return dest
 end
+
+# Pretty-printing for sparse arrays
+function Base.replace_in_print_matrix(B::BlockDiagonal, i::Integer, j::Integer, s::AbstractString)
+    p, ip, jp = _block_indices(B, i, j)
+    p == -1 && return Base.replace_with_centered_mark(s)
+    b = getblock(B, p)
+    jp += last(axes(b, 2))
+    Base.replace_in_print_matrix(b, ip, jp, s)
+end

--- a/test/blockdiagonal.jl
+++ b/test/blockdiagonal.jl
@@ -67,6 +67,17 @@ using Test
             # Should not allow setting value outside on-diagonal blocks to non-zero
             @test_throws ArgumentError X[1, 7] = 1
         end
+
+        @testset "pretty-printing" begin
+            io = IOBuffer()
+            d = Diagonal(1:6)
+            Base.print_array(io, d)
+            s1 = String(take!(io))
+            b = BlockDiagonal([Diagonal(1:3), Diagonal(4:6)])
+            Base.print_array(io, b)
+            s2 = String(take!(io))
+            @test s1 == s2
+        end
     end  # AbstractArray
 
     @testset "isequal_blocksizes" begin


### PR DESCRIPTION
This PR makes the display of block-diagonals similar to that of diagonals, by replacing the zero elements with dots.

After this PR
```julia
julia> Diagonal(1:4)
4×4 Diagonal{Int64, UnitRange{Int64}}:
 1  ⋅  ⋅  ⋅
 ⋅  2  ⋅  ⋅
 ⋅  ⋅  3  ⋅
 ⋅  ⋅  ⋅  4

julia> BlockDiagonal([Diagonal(1:2), Diagonal(3:4)])
4×4 BlockDiagonal{Int64, Diagonal{Int64, UnitRange{Int64}}}:
 1  ⋅  ⋅  ⋅
 ⋅  2  ⋅  ⋅
 ⋅  ⋅  3  ⋅
 ⋅  ⋅  ⋅  4
```

This makes the structure easy to interpret