### PR TITLE
Disambiguate (::ProjectTo)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.24"
+version = "0.1.25"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -84,7 +84,7 @@ function ProjectTo(b::BlockDiagonal)
     return ProjectTo{BlockDiagonal}(; blocks=blocks, blocksizes=blocksizes(b))
 end
 
-function (project::ProjectTo{BlockDiagonal})(dx)
+function (project::ProjectTo{BlockDiagonal})(dx::AbstractArray)
     # prepare to index into the dense array
     nrows = first.(project.blocksizes)
     ncols = last.(project.blocksizes)

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -31,5 +31,7 @@
         @test project(adjoint(ones(5, 5))) == bd
         @test project(Diagonal(ones(5))) isa BlockDiagonal
         @test project(Diagonal(ones(5))) == Diagonal(ones(5))
+
+        @test ProjectTo(bd)(ChainRulesCore.ZeroTangent()) == ChainRulesCore.ZeroTangent()
     end
 end


### PR DESCRIPTION
This resolves #84 by slightly restricting the type signature of `(::ProjectTo{BlockDiagonal})(dx)` to `(::ProjectTo{BlockDiagonal})(dx::AbstractArray)`. This follows the pattern established in ChainRulesCore's `ProjectTo` definitions for linear algebra.