### PR TITLE
Reduce allocations in `_block_indices`

### DIFF
--- a/src/blockdiagonal.jl
+++ b/src/blockdiagonal.jl
@@ -145,17 +145,15 @@ end
 # that the same entry is available via `getblock(B, p)[i, end+j]`; `p = -1` if no such `p`.
 function _block_indices(B::BlockDiagonal, i::Integer, j::Integer)
     all((0, 0) .< (i, j) .<= size(B)) || throw(BoundsError(B, (i, j)))
-    nrows = size.(blocks(B), 1)
-    ncols = size.(blocks(B), 2)
     # find the on-diagonal block `p` in column `j`
     p = 0
-    while j > 0
+    @inbounds while j > 0
         p += 1
-        j -= ncols[p]
+        j -= size(blocks(B)[p], 2)
     end
-    i -= sum(nrows[1:(p-1)])
+    @views @inbounds i -= sum(size.(blocks(B)[1:(p-1)], 1))
     # if row `i` outside of block `p`, set `p` to place-holder value `-1`
-    if i <= 0 || i > nrows[p]
+    if i <= 0 || i > size(blocks(B)[p], 1)
         p = -1
     end
     return p, i, j

--- a/src/blockdiagonal.jl
+++ b/src/blockdiagonal.jl
@@ -149,11 +149,11 @@ function _block_indices(B::BlockDiagonal, i::Integer, j::Integer)
     p = 0
     @inbounds while j > 0
         p += 1
-        j -= size(blocks(B)[p], 2)
+        j -= blocksize(B, p)[2]
     end
     @views @inbounds i -= sum(size.(blocks(B)[1:(p-1)], 1))
     # if row `i` outside of block `p`, set `p` to place-holder value `-1`
-    if i <= 0 || i > size(blocks(B)[p], 1)
+    if i <= 0 || i > blocksize(B, p)[1]
         p = -1
     end
     return p, i, j


### PR DESCRIPTION
`_block_indices` allocates two arrays that are the size of the number of blocks, no matter what the inputs are. This is quite slow, as it is done every time `getindex`, `setindex`, etc is called. It also makes a third allocation (calling `sum` on a slice of one of the aforementioned allocated arrays) but the size of this depends on the inputs.

This PR removes those allocations.

```julia
julia> x = [rand(5:30) for _ in 1:100]; y = Random.shuffle(x);

julia> z = BlockDiagonal([rand(x,y) for (x,y) in zip(x, y)]);

# before
julia> @allocated z[3, 3]
1888

# this PR
julia> @allocated z[3, 3]
96
```
