### PR TITLE
Fix the `diag` and `svdvals` bugs for non-square blocks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.27"
+version = "0.1.28"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -73,7 +73,14 @@ end
 
 
 svdvals_blockwise(B::BlockDiagonal) = mapreduce(svdvals, vcat, blocks(B))
-LinearAlgebra.svdvals(B::BlockDiagonal) = sort!(svdvals_blockwise(B); rev=true)
+function LinearAlgebra.svdvals(B::BlockDiagonal)
+    # if all the blocks are squares
+    if all(map(t -> t[1] == t[2], blocksizes(B)))
+        return sort!(svdvals_blockwise(B); rev=true)
+    else
+        return svdvals(Matrix(B))
+    end
+end
 
 # `B = U * Diagonal(S) * Vt` with `U` and `Vt` `BlockDiagonal` (`S` only sorted block-wise).
 function svd_blockwise(B::BlockDiagonal{T}; full::Bool=false) where T

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -4,7 +4,7 @@ for f in (:adjoint, :eigvecs, :inv, :pinv, :transpose)
     @eval LinearAlgebra.$f(B::BlockDiagonal) = BlockDiagonal(map($f, blocks(B)))
 end
 
-LinearAlgebra.diag(B::BlockDiagonal) = mapreduce(diag, vcat, blocks(B))
+LinearAlgebra.diag(B::BlockDiagonal) = map(i -> getindex(B, i, i), 1:minimum(size(B)))
 LinearAlgebra.det(B::BlockDiagonal) = prod(det, blocks(B))
 LinearAlgebra.logdet(B::BlockDiagonal) = sum(logdet, blocks(B))
 LinearAlgebra.tr(B::BlockDiagonal) = sum(tr, blocks(B))

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -16,6 +16,7 @@ end
     b1 = BlockDiagonal([rand(rng, N1, N1), rand(rng, N2, N2), rand(rng, N3, N3)])
     b2 = BlockDiagonal([rand(rng, N1, N1), rand(rng, N3, N3), rand(rng, N2, N2)])
     b3 = BlockDiagonal([rand(rng, N1, N1), rand(rng, N2, N2), rand(rng, N2, N2)])
+    b_nonsq = BlockDiagonal([rand(rng, N1, N2), rand(rng, N2, N1)])
     A = rand(rng, N, N + N1)
     B = rand(rng, N + N1, N + N2)
     A′, B′ = A', B'
@@ -36,8 +37,12 @@ end
     end
 
     @testset "Unary Linear Algebra" begin
+        nonsquare = (adjoint, diag, pinv, svdvals, transpose)
         @testset "$f" for f in (adjoint, det, diag, eigvals, inv, pinv, svdvals, transpose, tr)
             @test f(b1) ≈ f(Matrix(b1))
+            if f in nonsquare
+                @test f(b_nonsq) ≈ f(Matrix(b_nonsq))
+            end
         end
 
         @testset "permute=$p, scale=$s" for p in (true, false), s in (true, false)


### PR DESCRIPTION
Closes #95 , closes #67 