### PR TITLE
fix the getindex bug for abstract arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.29"
+version = "0.1.30"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/blockdiagonal.jl
+++ b/src/blockdiagonal.jl
@@ -152,7 +152,8 @@ function _block_indices(B::BlockDiagonal, i::Integer, j::Integer)
         p += 1
         j -= blocksize(B, p)[2]
     end
-    @views @inbounds i -= sum(size.(blocks(B)[1:(p-1)], 1))
+    # isempty to avoid reducing over an empty collection
+    @views @inbounds i -= isempty(1:(p-1)) ? 0 : sum(size.(blocks(B)[1:(p-1)], 1))
     # if row `i` outside of block `p`, set `p` to place-holder value `-1`
     if i <= 0 || i > blocksize(B, p)[1]
         p = -1

--- a/test/blockdiagonal.jl
+++ b/test/blockdiagonal.jl
@@ -124,4 +124,9 @@ using Test
 
         @test_throws DimensionMismatch copy!(b2, b1)
     end
+
+    @testset "getindex bug" begin
+        b = BlockDiagonal(AbstractMatrix{Float64}[ones(2, 2)])
+        @test b[1] == 1
+    end
 end


### PR DESCRIPTION
Fixes the bug in the test which gives
```julia
julia> b = BlockDiagonal(AbstractMatrix{Float64}[rand(2, 2)]);

julia> b[1]
ERROR: MethodError: no method matching zero(::Type{Any})
Closest candidates are:
  zero(::Type{Union{Missing, T}}) where T at /Applications/Julia-1.7.app/Contents/Resources/julia/share/julia/base/missing.jl:105
  zero(::Union{Type{P}, P}) where P<:Dates.Period at /Applications/Julia-1.7.app/Contents/Resources/julia/share/julia/stdlib/v1.7/Dates/src/periods.jl:53
  zero(::FillArrays.Ones{T, N}) where {T, N} at ~/.julia/packages/FillArrays/7oBjc/src/FillArrays.jl:539
  ...
Stacktrace:
  [1] zero(#unused#::Type{Any})
    @ Base ./missing.jl:106
  [2] reduce_empty(#unused#::typeof(+), #unused#::Type{Any})
    @ Base ./reduce.jl:313
  [3] reduce_empty(#unused#::typeof(Base.add_sum), #unused#::Type{Any})
    @ Base ./reduce.jl:322
  [4] mapreduce_empty(#unused#::typeof(identity), op::Function, T::Type)
    @ Base ./reduce.jl:345
  [5] reduce_empty(op::Base.MappingRF{typeof(identity), typeof(Base.add_sum)}, #unused#::Type{Any})
    @ Base ./reduce.jl:331
  [6] reduce_empty_iter
    @ ./reduce.jl:357 [inlined]
  [7] mapreduce_empty_iter(f::Function, op::Function, itr::Vector{Any}, ItrEltype::Base.HasEltype)
    @ Base ./reduce.jl:353
  [8] _mapreduce(f::typeof(identity), op::typeof(Base.add_sum), #unused#::IndexLinear, A::Vector{Any})
    @ Base ./reduce.jl:402
  [9] _mapreduce_dim
    @ ./reducedim.jl:330 [inlined]
 [10] #mapreduce#725
    @ ./reducedim.jl:322 [inlined]
 [11] mapreduce
    @ ./reducedim.jl:322 [inlined]
 [12] #_sum#735
    @ ./reducedim.jl:894 [inlined]
 [13] _sum
    @ ./reducedim.jl:894 [inlined]
 [14] #_sum#734
    @ ./reducedim.jl:893 [inlined]
 [15] _sum
    @ ./reducedim.jl:893 [inlined]
 [16] #sum#732
    @ ./reducedim.jl:889 [inlined]
 [17] sum(a::Vector{Any})
    @ Base ./reducedim.jl:889
 [18] _block_indices(B::BlockDiagonal{Float64, AbstractMatrix{Float64}}, i::Int64, j::Int64)
    @ BlockDiagonals ~/JuliaEnvs/GPForecasting.jl/dev/BlockDiagonals/src/blockdiagonal.jl:158
 [19] getindex(B::BlockDiagonal{Float64, AbstractMatrix{Float64}}, i::Int64, j::Int64)
    @ BlockDiagonals ~/JuliaEnvs/GPForecasting.jl/dev/BlockDiagonals/src/blockdiagonal.jl:140
 [20] _getindex
    @ ./abstractarray.jl:1257 [inlined]
 [21] getindex(A::BlockDiagonal{Float64, AbstractMatrix{Float64}}, I::Int64)
    @ Base ./abstractarray.jl:1218
 [22] top-level scope
    @ REPL[84]:1
```