### PR TITLE
implement `Base.copy`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.30"
+version = "0.1.31"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/blockdiagonal.jl
+++ b/src/blockdiagonal.jl
@@ -161,6 +161,10 @@ function _block_indices(B::BlockDiagonal, i::Integer, j::Integer)
     return p, i, j
 end
 
+function Base.copy(b::BlockDiagonal)
+    return BlockDiagonal(copy.(blocks(b)))
+end
+
 function Base.copy!(dest::BlockDiagonal, src::BlockDiagonal)
     isequal_blocksizes(dest, src) || throw(DimensionMismatch("dest and src have different block sizes"))
     for i in eachindex(blocks(dest))


### PR DESCRIPTION
Closes #101 

The fallback method in Base resorts to looping over eachindex, including the off-diagonal ones.