### PR TITLE
Convert between `BlockDiagonals` of different block types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.30"
+version = "0.1.31"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/blockdiagonal.jl
+++ b/src/blockdiagonal.jl
@@ -142,6 +142,11 @@ end
     @inbounds return p > 0 ? getblock(B, p)[i, end + j] : zero(T)
 end
 
+function Base.convert(::Type{BlockDiagonal{T, M}}, b::BlockDiagonal) where {T, M}
+    new_blocks = convert.(M, blocks(b))
+    return BlockDiagonal(new_blocks)::BlockDiagonal{T, M}
+end
+
 # Transform indices `i, j` (identifying entry `Matrix(B)[i, j]`) into indices `p, i, j` such
 # that the same entry is available via `getblock(B, p)[i, end+j]`; `p = -1` if no such `p`.
 function _block_indices(B::BlockDiagonal, i::Integer, j::Integer)

--- a/test/blockdiagonal.jl
+++ b/test/blockdiagonal.jl
@@ -129,4 +129,16 @@ using Test
         b = BlockDiagonal(AbstractMatrix{Float64}[ones(2, 2)])
         @test b[1] == 1
     end
+
+    @testset "convert(BlockDiagonal{F, T{F}}, block_diagonal)" for T in (
+        Symmetric, UpperTriangular, Transpose, Hermitian
+    )
+        special = T(rand(2, 2))
+        b = BlockDiagonal([special])
+
+        convert_first = BlockDiagonal([convert(Matrix, special)])
+        convert_last = convert(BlockDiagonal{Float64, Matrix{Float64}}, b)
+
+        @test convert_first == convert_last
+    end
 end


### PR DESCRIPTION
Helps with #102 

The idea is that if
```julia
julia> convert(Matrix, Symmetric(rand(2, 2)))
```
is allowed, then so should `convert` between `BlockDiagonal`s where the blocks are of these types, e.g.
```julia
julia> convert(BlockDiagonal{Float64, Matrix{Float64}}, BlockDiagonal([Symmetric(rand(2, 2))]))
```