### PR TITLE
Matrixify cholesky components

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,13 +14,15 @@ ChainRulesCore = "1"
 ChainRulesTestUtils = "1"
 FillArrays = "0.6, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13"
 FiniteDifferences = "0.12.3"
+PDMats = "0.11"
 julia = "1"
 
 [extras]
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ChainRulesTestUtils", "Documenter", "Random", "Test"]
+test = ["ChainRulesTestUtils", "Documenter", "PDMats", "Random", "Test"]

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -105,7 +105,7 @@ function LinearAlgebra.svd(B::BlockDiagonal; full::Bool=false)::SVD
 end
 
 function LinearAlgebra.cholesky(B::BlockDiagonal)::Cholesky
-    C = BlockDiagonal(map(b -> cholesky(b).U.data, blocks(B)))
+    C = BlockDiagonal(map(b -> parent(cholesky(b).U), blocks(B)))
     return Cholesky(C, 'U', 0)
 end
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -105,7 +105,7 @@ function LinearAlgebra.svd(B::BlockDiagonal; full::Bool=false)::SVD
 end
 
 function LinearAlgebra.cholesky(B::BlockDiagonal)::Cholesky
-    C = BlockDiagonal(map(b -> cholesky(b).U, blocks(B)))
+    C = BlockDiagonal(map(b -> Matrix(cholesky(b).U), blocks(B)))
     return Cholesky(C, 'U', 0)
 end
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -105,7 +105,7 @@ function LinearAlgebra.svd(B::BlockDiagonal; full::Bool=false)::SVD
 end
 
 function LinearAlgebra.cholesky(B::BlockDiagonal)::Cholesky
-    C = BlockDiagonal(map(b -> Matrix(cholesky(b).U), blocks(B)))
+    C = BlockDiagonal(map(b -> cholesky(b).U.data, blocks(B)))
     return Cholesky(C, 'U', 0)
 end
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -181,6 +181,7 @@ end
         @test C.UL ≈ C.U
         @test C.uplo === 'U'
         @test C.info == 0
+        @test typeof(C) == Cholesky{Float64, BlockDiagonal{Float64, Matrix{Float64}}}
 
         M = BlockDiagonal(map(Matrix, blocks(C.L)))
         C = Cholesky(M, 'L', 0)
@@ -190,6 +191,7 @@ end
         @test C.UL ≈ C.L
         @test C.uplo === 'L'
         @test C.info == 0
+        @test typeof(C) == Cholesky{Float64, BlockDiagonal{Float64, Matrix{Float64}}}
     end  # Cholesky
     @testset "Singular Value Decomposition" begin
         X = [  4  12 -16

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -182,6 +182,7 @@ end
         @test C.uplo === 'U'
         @test C.info == 0
         @test typeof(C) == Cholesky{Float64, BlockDiagonal{Float64, Matrix{Float64}}}
+        @test PDMat(cholesky(BD)) == PDMat(cholesky(Matrix(BD)))
 
         M = BlockDiagonal(map(Matrix, blocks(C.L)))
         C = Cholesky(M, 'L', 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using ChainRulesCore
 using ChainRulesTestUtils
 using Documenter
 using FiniteDifferences # For overloading to_vec
+using PDMats
 using Test
 using LinearAlgebra
 


### PR DESCRIPTION
Closes https://github.com/invenia/BlockDiagonals.jl/issues/102

This makes sure that the `cholesky` decomposition of `BlockDiagonal`, which is also a `BlockDiagonal`, has the right block type.

```julia
julia> x = rand(2, 2);

julia> s = Symmetric(x' * x);

julia> cholesky(s)
Cholesky{Float64, Matrix{Float64}}
U factor:
2×2 UpperTriangular{Float64, Matrix{Float64}}:
 0.247162  0.82171
  ⋅        0.583208

julia> b = BlockDiagonal([s]);

julia> cholesky(b)
Cholesky{Float64, BlockDiagonal{Float64, Matrix{Float64}}}
U factor:
2×2 BlockDiagonal{Float64, UpperTriangular{Float64, Matrix{Float64}}}:
 0.247162  0.82171
 0.0       0.583208
```

rather than the current
```julia
julia> cholesky(b)
Cholesky{Float64, BlockDiagonal{Float64, UpperTriangular{Float64, Matrix{Float64}}}}
U factor:
2×2 BlockDiagonal{Float64, UpperTriangular{Float64, Matrix{Float64}}}:
 0.247162  0.82171
 0.0       0.583208
```

My worry is that this is technically breaking. Any concerns about this?