### PR TITLE
Fix _densification_pullback bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.34"
+version = "0.1.35"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -25,7 +25,7 @@ function ChainRulesCore.rrule(::Type{<:BlockDiagonal}, blocks::Vector{V}) where 
 end
 
 # densification
-function _densification_pullback(Ȳ::Matrix, T, nrows, ncols)
+function _densification_pullback(Ȳ::AbstractMatrix, T, nrows, ncols)
     row_idxs = cumsum(nrows) .- nrows .+ 1
     col_idxs = cumsum(ncols) .- ncols .+ 1
 

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -14,8 +14,9 @@
     end
 
     @testset "Matrix" begin
-        D = BlockDiagonal([randn(1, 2), randn(2, 2)])
+        D = BlockDiagonal([randn(2, 2), randn(2, 2)])
         test_rrule(Matrix, D)
+        test_rrule(Matrix, D, output_tangent=UpperTriangular(rand(4, 4)))
     end
 
     @testset "BlockDiagonal * Vector" begin


### PR DESCRIPTION
Found in https://github.com/invenia/LinearMixingModels.jl/issues/51

Previously we had
```julia
julia> test_rrule(Matrix, D, output_tangent=UpperTriangular(rand(4, 4)))
test_rrule: Matrix on BlockDiagonal{Float64, Matrix{Float64}}: Error During Test at /Users/mzgubic/.julia/environments/v1.7/dev/ChainRulesTestUtils/src/testers.jl:193
  Got exception outside of a @test
  MethodError: no method matching _densification_pullback(::UpperTriangular{Float64, Matrix{Float64}}, ::Type{BlockDiagonal{Float64, Matrix{Float64}}}, ::Vector{Int64}, ::Vector{Int64})
  Closest candidates are:
    _densification_pullback(::ChainRulesCore.AbstractThunk, ::Any, ::Any, ::Any) at ~/JuliaEnvs/LinearMixingModels.jl/dev/BlockDiagonals/src/chainrules.jl:39
    _densification_pullback(::Matrix, ::Any, ::Any, ::Any) at ~/JuliaEnvs/LinearMixingModels.jl/dev/BlockDiagonals/src/chainrules.jl:28
```

This fixes the bug