### PR TITLE
implement faster subtraction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.35"
+version = "0.1.36"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/base_maths.jl
+++ b/src/base_maths.jl
@@ -66,6 +66,8 @@ end
 ## Subtraction
 Base.:-(B::BlockDiagonal) = BlockDiagonal(.-(blocks(B)))
 Base.:-(M::AbstractMatrix, B::BlockDiagonal) =  M + -B
+Base.:-(B::BlockDiagonal, M::AbstractMatrix) =  -M + B
+Base.:-(B::BlockDiagonal, B2::BlockDiagonal) =  B + (-B2)
 
 ## Multiplication
 Base.:*(n::Number, B::BlockDiagonal) = B * n

--- a/test/base_maths.jl
+++ b/test/base_maths.jl
@@ -76,6 +76,8 @@ using Test
         
         @test -b1 == -Matrix(b1)
         @test b1 - b1 == Matrix(b1) - Matrix(b1)
+        @test Matrix(b1) - b2 == Matrix(b1) - Matrix(b2)
+        @test b1 - Matrix(b2) == Matrix(b1) - Matrix(b2)
     end
 
     @testset "Multiplication" begin


### PR DESCRIPTION
Closes #112 

```julia
julia> bd = BlockDiagonal([rand(5, 5) for _ in 1:100]);

julia> dense1 = rand(500, 500);

julia> dense2 = rand(500, 500);

julia> @time bd - dense1;
  0.002135 seconds (104 allocations: 3.839 MiB)

julia> @time dense2 - dense1;
  0.001174 seconds (2 allocations: 1.907 MiB)
```

The default implementation fell back on
```julia
julia> @which bd - dense1
-(A::AbstractArray, B::AbstractArray) in Base at arraymath.jl:37
```
which did the inefficient `eachindex` loop to do the subtraction.
