### PR TITLE
Correctly handle `size` when `blocks` is empty

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.36"
+version = "0.1.37"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/blockdiagonal.jl
+++ b/src/blockdiagonal.jl
@@ -121,7 +121,7 @@ Base.collect(B::BlockDiagonal) = Matrix(B)
 
 # init kwarg for sum introduced in v1.6
 # see https://github.com/JuliaLang/julia/blob/master/base/reduce.jl#L492
-@static if VERSION  < v"1.6"
+@static if VERSION < v"1.6"
     function Base.size(B::BlockDiagonal)
         if isempty(blocks(B))
             return 0, 0

--- a/src/blockdiagonal.jl
+++ b/src/blockdiagonal.jl
@@ -119,7 +119,20 @@ end
 
 Base.collect(B::BlockDiagonal) = Matrix(B)
 
-Base.size(B::BlockDiagonal) = sum(first∘size, blocks(B)), sum(last∘size, blocks(B))
+# init kwarg for sum introduced in v1.6
+# see https://github.com/JuliaLang/julia/blob/master/base/reduce.jl#L492
+@static if VERSION  < v"1.6"
+    function Base.size(B::BlockDiagonal)
+        if isempty(blocks(B))
+            return 0, 0
+        else
+            return sum(first∘size, blocks(B)), sum(last∘size, blocks(B))
+        end
+    end
+else
+   Base.size(B::BlockDiagonal) = sum(first∘size, blocks(B); init=0), sum(last∘size, blocks(B); init=0)
+end
+
 Base.similar(B::BlockDiagonal) = BlockDiagonal(map(similar, blocks(B)))
 Base.similar(B::BlockDiagonal, ::Type{T}) where T = BlockDiagonal(map(b -> similar(b, T), blocks(B)))
 Base.parent(B::BlockDiagonal) = B.blocks

--- a/test/blockdiagonal.jl
+++ b/test/blockdiagonal.jl
@@ -84,6 +84,11 @@ using Test
         @test blocksize(B, 2) == blocksizes(B)[2] == blocksize(B, 2, 2)
     end
 
+    @testset "no blocks" begin
+        B = BlockDiagonal(Matrix{Float64}[]);
+        @test size(B) == (0, 0)
+    end
+
     @testset "Equality" begin
         # Equality
         @test b1 == b1


### PR DESCRIPTION
Related to `show` error in #30