### PR TITLE
Fix method ambiguity for `*` between `Adjoint` or `Transpose` and `BlockDiagonal` with different eltype

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.39"
+version = "0.1.40"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/base_maths.jl
+++ b/src/base_maths.jl
@@ -162,11 +162,11 @@ function Base.:*(M::Diagonal{T}, B::BlockDiagonal{T2})::BlockDiagonal where {T, 
     return A
 end
 
-function Base.:*(vt::Adjoint{T,<: AbstractVector}, B::BlockDiagonal{T}) where {T}
+function Base.:*(vt::Adjoint{T,<: AbstractVector}, B::BlockDiagonal{T2, V}) where V<:AbstractMatrix{T2} where {T, T2}
     return (B' * parent(vt))'
 end
 
-function Base.:*(vt::Transpose{T,<: AbstractVector}, B::BlockDiagonal{T}) where {T}
+function Base.:*(vt::Transpose{T,<: AbstractVector}, B::BlockDiagonal{T2, V}) where V<:AbstractMatrix{T2} where {T, T2}
     return transpose(transpose(B) * parent(vt))
 end
 

--- a/src/base_maths.jl
+++ b/src/base_maths.jl
@@ -162,7 +162,7 @@ function Base.:*(M::Diagonal{T}, B::BlockDiagonal{T2})::BlockDiagonal where {T, 
     return A
 end
 
-function Base.:*(vt::Adjoint{T,<: AbstractVector}, B::BlockDiagonal{T2, V}) where V<:AbstractMatrix{T2} where {T, T2}
+function Base.:*(vt::Adjoint{<:Any,<:AbstractVector}, B::BlockDiagonal)
     return (B' * parent(vt))'
 end
 

--- a/src/base_maths.jl
+++ b/src/base_maths.jl
@@ -166,7 +166,7 @@ function Base.:*(vt::Adjoint{<:Any,<:AbstractVector}, B::BlockDiagonal)
     return (B' * parent(vt))'
 end
 
-function Base.:*(vt::Transpose{T,<: AbstractVector}, B::BlockDiagonal{T2, V}) where V<:AbstractMatrix{T2} where {T, T2}
+function Base.:*(vt::Transpose{<:Any,<:AbstractVector}, B::BlockDiagonal)
     return transpose(transpose(B) * parent(vt))
 end
 

--- a/test/base_maths.jl
+++ b/test/base_maths.jl
@@ -19,6 +19,8 @@ using Test
     b64 = BlockDiagonal([rand(rng, 2, 2), rand(rng, 2, 2)])
     b32 = BlockDiagonal([rand(rng, Float32, 2, 2), rand(rng, Float32, 2, 2)])
 
+    bi = BlockDiagonal([zeros(Int, N1, N1), zeros(Int, N2, N2), zeros(Int, N3, N3)])
+
     bns = BlockDiagonal([rand(rng, N1, N2), rand(rng, N2, N3), rand(rng, N3, N1)])
 
     @testset "Addition" begin
@@ -120,6 +122,8 @@ using Test
             @test transpose(a) * b1 isa Transpose{<:Number, <:Vector}
             @test a' * b1 ≈ a' * Matrix(b1)
             @test transpose(a) * b1 ≈ transpose(a) * Matrix(b1)
+            # # Method ambiguity bug https://github.com/invenia/BlockDiagonals.jl/issues/91
+            @test a' * bi isa Adjoint{<:Number, <:Vector}
         end
 
         @testset "BlockDiagonal * Matrix" begin

--- a/test/base_maths.jl
+++ b/test/base_maths.jl
@@ -122,7 +122,7 @@ using Test
             @test transpose(a) * b1 isa Transpose{<:Number, <:Vector}
             @test a' * b1 ≈ a' * Matrix(b1)
             @test transpose(a) * b1 ≈ transpose(a) * Matrix(b1)
-            # Method ambiguity bug https://github.com/invenia/BlockDiagonals.jl/issues/91
+            # Method ambiguity with different eltypes https://github.com/invenia/BlockDiagonals.jl/issues/91
             @test a' * bi isa Adjoint{<:Number, <:Vector}
         end
 

--- a/test/base_maths.jl
+++ b/test/base_maths.jl
@@ -122,7 +122,7 @@ using Test
             @test transpose(a) * b1 isa Transpose{<:Number, <:Vector}
             @test a' * b1 ≈ a' * Matrix(b1)
             @test transpose(a) * b1 ≈ transpose(a) * Matrix(b1)
-            # # Method ambiguity bug https://github.com/invenia/BlockDiagonals.jl/issues/91
+            # Method ambiguity bug https://github.com/invenia/BlockDiagonals.jl/issues/91
             @test a' * bi isa Adjoint{<:Number, <:Vector}
         end
 


### PR DESCRIPTION
closes #91