### PR TITLE
Correct `+(::BlockDiagonal, ::StridedMatrix)` for non-square blocks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.40"
+version = "0.1.41"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/base_maths.jl
+++ b/src/base_maths.jl
@@ -33,11 +33,14 @@ function Base.:+(B::BlockDiagonal, M::StridedMatrix)
     end
     A = copy(M)
     row = 1
-    for (j, block) in enumerate(blocks(B))
-        nrows = size(block, 1)
-        rows = row:(row + nrows-1)
-        A[rows, rows] .+= block
+    col = 1
+    for block in blocks(B)
+        nrows, ncols = size(block)
+        rows = row:(row + nrows - 1)
+        cols = col:(col + ncols - 1)
+        A[rows, cols] .+= block
         row += nrows
+        col += ncols
     end
     return A
 end

--- a/test/base_maths.jl
+++ b/test/base_maths.jl
@@ -35,6 +35,10 @@ using Test
             @test b1 + Matrix(b1) == b1 + b1
             @test_throws DimensionMismatch b1 + Matrix(b3)
 
+            # Test on non-square blocks
+            # https://github.com/invenia/BlockDiagonals.jl/issues/124
+            @test bns + Matrix(bns) == Matrix(bns) + Matrix(bns)
+
             # Matrix + BlockDiagonal
             @test Matrix(b1) + b1 isa Matrix
             @test Matrix(b1) + b1 == b1 + b1

--- a/test/base_maths.jl
+++ b/test/base_maths.jl
@@ -22,6 +22,7 @@ using Test
     bi = BlockDiagonal([zeros(Int, N1, N1), zeros(Int, N2, N2), zeros(Int, N3, N3)])
 
     bns = BlockDiagonal([rand(rng, N1, N2), rand(rng, N2, N3), rand(rng, N3, N1)])
+    C = rand(rng, N, N)
 
     @testset "Addition" begin
         @testset "BlockDiagonal + BlockDiagonal" begin
@@ -38,6 +39,7 @@ using Test
             # Test on non-square blocks
             # https://github.com/invenia/BlockDiagonals.jl/issues/124
             @test bns + Matrix(bns) == Matrix(bns) + Matrix(bns)
+            @test bns + C == Matrix(bns) + C
 
             # Matrix + BlockDiagonal
             @test Matrix(b1) + b1 isa Matrix


### PR DESCRIPTION
Closes #124 