### PR TITLE
Allow block multiplication of non-square blocks

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -138,18 +138,16 @@ if VERSION ≥ v"1.3"
 end
 
 function _mul!(C::BlockDiagonal, A::BlockDiagonal, B::BlockDiagonal)
-    isequal_blocksizes(A, B) || throw(DimensionMismatch("A and B have different block sizes"))
-    isequal_blocksizes(C, A) || throw(DimensionMismatch("C has incompatible block sizes"))
+    can_block_multiply(C,A,B) || throw(DimensionMismatch("A has blocksizes $(blocksizes(A)), B has blocksizes $(blocksizes(B)), C has blocksizes $(blocksizes(C))"))
     for i in eachindex(blocks(C))
         @inbounds LinearAlgebra.mul!(C.blocks[i], A.blocks[i], B.blocks[i])
     end
 
     return C
 end
-
+#
 function _mul!(C::BlockDiagonal, A::BlockDiagonal, B::BlockDiagonal, α::Number, β::Number)
-    isequal_blocksizes(A, B) || throw(DimensionMismatch("A and B have different block sizes"))
-    isequal_blocksizes(C, A) || throw(DimensionMismatch("C has incompatible block sizes"))
+    can_block_multiply(C,A,B) || throw(DimensionMismatch("A has blocksizes $(blocksizes(A)), B has blocksizes $(blocksizes(B)), C has blocksizes $(blocksizes(C))"))
     for i in eachindex(blocks(C))
         @inbounds LinearAlgebra.mul!(C.blocks[i], A.blocks[i], B.blocks[i], α, β)
     end

--- a/test/base_maths.jl
+++ b/test/base_maths.jl
@@ -183,6 +183,15 @@ using Test
             # Dimension check
             @test sum(size.(b4.blocks, 1)) == size(b4 * b5, 1)
             @test sum(size.(b5.blocks, 2)) == size(b4 * b5, 2)
+
+            b6 = BlockDiagonal([ones(4, 1), 2 * ones(2, 2)])
+            b46 = b4 * b6
+            @test b46 isa BlockDiagonal
+            @test b46 == [4 * ones(2,1)  zeros(2,2); zeros(3,1) 8* ones(3,2)]
+            @test sum(size.(b4.blocks, 1)) == size(b46, 1)
+            @test sum(size.(b6.blocks, 2)) == size(b46, 2)
+
+            @test_throws DimensionMismatch b6 * b4
         end
     end  # Multiplication
 end

--- a/test/blockdiagonal.jl
+++ b/test/blockdiagonal.jl
@@ -1,5 +1,5 @@
 using BlockDiagonals
-using BlockDiagonals: isequal_blocksizes
+using BlockDiagonals: isequal_blocksizes, can_block_multiply
 using Random
 using Test
 
@@ -75,6 +75,15 @@ using Test
         @test isequal_blocksizes(b1, b1) == true
         @test isequal_blocksizes(b1, similar(b1)) == true
         @test isequal_blocksizes(b1, b2) == false
+    end
+
+    @testset "can_block_multiply" begin
+        @test can_block_multiply(b1, b1) == true
+        @test can_block_multiply(b1, b2) == false
+
+        @test can_block_multiply(b1, b1, b1) == true
+        @test can_block_multiply(b1, b1, b2) == false
+        @test can_block_multiply(b2, b1, b1) == false
     end
 
     @testset "blocks size" begin


### PR DESCRIPTION
Currently, BlockDiagonals keeps the block structure in matrix multiplication only if the blocks that are multiplied together have the same size. This is overly restrictive and rules out multiplication with non-square blocks. 

This PR modifies the check done when multiplying BlockDiagonals to permit multiplication with non-square blocks while retaining the block diagonal structure. 

In addition, the overhead of checking if blocks can be multiplied or added has been reduced.