### PR TITLE
Use StableRNGs, make b2 symmetric for real eigen values and don't con…

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ FiniteDifferences = "0.12.3"
 LinearAlgebra = "1.6"
 PDMats = "0.11"
 julia = "1.6"
-
+StableRNGs = "1.0.2"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
@@ -26,6 +26,7 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 
 [targets]
-test = ["BenchmarkTools", "ChainRulesTestUtils", "Documenter", "PDMats", "Random", "Test"]
+test = ["BenchmarkTools", "ChainRulesTestUtils", "Documenter", "PDMats", "StableRNGs", "Test"]

--- a/test/base_maths.jl
+++ b/test/base_maths.jl
@@ -1,10 +1,10 @@
 using BlockDiagonals
 using LinearAlgebra: Diagonal, I
-using Random
+using StableRNGs
 using Test
 
 @testset "base_maths.jl" begin
-    rng = MersenneTwister(123456)
+    rng = StableRNG(123456)
     N1, N2, N3 = 3, 4, 5
     N = N1 + N2 + N3
     b1 = BlockDiagonal([rand(rng, N1, N1), rand(rng, N2, N2), rand(rng, N3, N3)])

--- a/test/blockdiagonal.jl
+++ b/test/blockdiagonal.jl
@@ -1,10 +1,10 @@
 using BlockDiagonals
 using BlockDiagonals: isequal_blocksizes
-using Random
+using StableRNGs
 using Test
 
 @testset "blockdiagonal.jl" begin
-    rng = MersenneTwister(123456)
+    rng = StableRNG(123456)
     N1, N2, N3 = 3, 4, 5
     N = N1 + N2 + N3
     b1 = BlockDiagonal([rand(rng, N1, N1), rand(rng, N2, N2), rand(rng, N3, N3)])


### PR DESCRIPTION
…vert to complex because it messes up the complex conjugates to fix test failures