### PR TITLE
Test on prereleases instead of nightly

### DIFF
--- a/.github/workflows/JuliaPrerelease.yml
+++ b/.github/workflows/JuliaPrerelease.yml
@@ -2,8 +2,8 @@ name: JuliaNightly
 # Nightly Scheduled Julia Nightly Run
 on:
   schedule:
-    - cron: '0 2 * * *'  # Daily at 2 AM UTC (8 PM CST)
-  workflow_dispath:
+    - cron: '0 2 * * 0'  # Sundays at 2 AM UTC (8 PM CST)
+  workflow_dispatch:
 jobs:
   test:
     name: Julia Prerelease - Ubuntu - x64

--- a/.github/workflows/JuliaPrerelease.yml
+++ b/.github/workflows/JuliaPrerelease.yml
@@ -3,19 +3,20 @@ name: JuliaNightly
 on:
   schedule:
     - cron: '0 2 * * *'  # Daily at 2 AM UTC (8 PM CST)
+  workflow_dispath:
 jobs:
   test:
-    name: Julia Nightly - Ubuntu - x64
+    name: Julia Prerelease - Ubuntu - x64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: nightly
+          version: pre
           arch: x64
       - uses: actions/cache@v4
         env:
-          cache-name: julia-nightly-cache-artifacts
+          cache-name: julia-prerelease-cache-artifacts
         with:
           path: ~/.julia/artifacts
           key: ${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}


### PR DESCRIPTION
Nightly is volatile so end up numb to test failures