### PR TITLE
Make `BlockDiagonal` block storage generic

### DIFF
--- a/ext/ChainRulesCoreExt.jl
+++ b/ext/ChainRulesCoreExt.jl
@@ -58,7 +58,7 @@ function ChainRulesCore.rrule(
     ::typeof(*),
     bm::BlockDiagonal{T,V},
     v::StridedVector{T},
-) where {T<:Union{Real,Complex},V<:Matrix{T}}
+) where {T<:Union{Real,Complex},V<:AbstractVector{<:Matrix{T}}}
 
     y = bm * v
 

--- a/test/blockdiagonal.jl
+++ b/test/blockdiagonal.jl
@@ -175,7 +175,7 @@ using Test
         b = BlockDiagonal([special])
 
         convert_first = BlockDiagonal([convert(Matrix, special)])
-        convert_last = convert(BlockDiagonal{Float64,Matrix{Float64}}, b)
+        convert_last = convert(BlockDiagonal{Float64,Vector{Matrix{Float64}}}, b)
 
         @test convert_first == convert_last
     end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -160,7 +160,7 @@ end
         @test C.UL ≈ C.U
         @test C.uplo === 'U'
         @test C.info == 0
-        @test typeof(C) == Cholesky{Float64,BlockDiagonal{Float64,Matrix{Float64}}}
+        @test typeof(C) == Cholesky{Float64,BlockDiagonal{Float64,Vector{Matrix{Float64}}}}
         @test PDMat(cholesky(BD)) == PDMat(cholesky(Matrix(BD)))
 
         M = BlockDiagonal(map(Matrix, blocks(C.L)))
@@ -171,7 +171,7 @@ end
         @test C.UL ≈ C.L
         @test C.uplo === 'L'
         @test C.info == 0
-        @test typeof(C) == Cholesky{Float64,BlockDiagonal{Float64,Matrix{Float64}}}
+        @test typeof(C) == Cholesky{Float64,BlockDiagonal{Float64,Vector{Matrix{Float64}}}}
 
         # we didn't think we needed to support this, but #109
         d = Diagonal(rand(5))


### PR DESCRIPTION
Before this commit, `BlockDiagonal` uses a `Vector{V}` to store the blocks. The issue is that for trimmable binaries it is advantageous to use stronger typing, such as `SizedVector` from `StaticArrays`. To support such cases, we make the vector type generic, and make the required modifications in the rest of the package.